### PR TITLE
Fix: channels overview session leap link

### DIFF
--- a/pages/docs/channels/overview.mdx
+++ b/pages/docs/channels/overview.mdx
@@ -39,7 +39,7 @@ You can connect and authenticate with Channels multiple times under the same tok
 
 ### Sessions
 
-When a client SDK connects to the Channels socket, they are attached to a session individual to that token. Then, if a user connects multiple times under one token, they are connected to the same session. As a developer, you shouldn't need to worry about this resource - just know that it's used to keep a consistent and uninterrupted socket connection during unstable network conditions. Sessions automatically die once there have been no connected clients for a 30 second period. You can read more about them in the [Leap](./leap) documentation.
+When a client SDK connects to the Channels socket, they are attached to a session individual to that token. Then, if a user connects multiple times under one token, they are connected to the same session. As a developer, you shouldn't need to worry about this resource - just know that it's used to keep a consistent and uninterrupted socket connection during unstable network conditions. Sessions automatically die once there have been no connected clients for a 30 second period. You can read more about them in the [Leap](internals/leap) documentation.
 
 #### Connections
 


### PR DESCRIPTION
simply fix the actual leap link