### PR TITLE
Improve custom domain documentation

### DIFF
--- a/pages/ignite/gateways.mdx
+++ b/pages/ignite/gateways.mdx
@@ -75,3 +75,7 @@ You will be presented with this modal, where you should enter your desired domai
 </Bleed>
 
 Click **Next**.
+
+After this, you will be required to create a CNAME record for your previously entered domain pointing to Hop.
+
+Details about this record will be shown on screen in a modal after entering the domain.


### PR DESCRIPTION
On the documentation page for Ignite Gateways, it is described how one adds a custom domain. It ends with pressing "Next" after entering the domain, which might cause some confusion when reading just the docs and not following along.

Whilst the modal on Hop guides the user on how to proceed (adding the CNAME record) it would be good to also have this information on the docs and therefore I have added it.

(This is my first PR to the docs, please let me know if I did something wrong or forgot something)