### PR TITLE
Fix dead links and add examples to JS SDK Docs

### DIFF
--- a/ignite/images.mdx
+++ b/ignite/images.mdx
@@ -24,7 +24,7 @@ You'll need Docker installed on your machine to do this.
 #### Obtain a Personal Access Token
 
 To log in to the registry, you'll have to use a Hop PAT. They can be created
-from [this page](https://console.hop.io/auth) on the console (User Settings ->
+from [this page](https://console.hop.io/project/settings/tokens) on the console (User Settings ->
 Personal Tokens).
 
 Click on the "Create Token" button in the top right, optionally give it a name

--- a/ignite/private-networking.mdx
+++ b/ignite/private-networking.mdx
@@ -15,6 +15,6 @@ Each Hop region that you use within a project gets its own `/16` subnet. Even th
 
 ## Container Addressing & Internal Gateways
 
-Every container that gets deployed to Hop automatically gets assigned it's own private IP address. All containers are able to talk to each other using these addresses, however, because containers are usually treated in an ephemeral manner, it's recommended to use an [Internal Gateway](http://localhost:3001/ignite/gateways#creating-a-gateway) to route between services instead of using the container IPs directly. Internal gateways give you an "internal domain" which you can use to dynamically resolve the IP addresses of containers under a specific deployment.
+Every container that gets deployed to Hop automatically gets assigned it's own private IP address. All containers are able to talk to each other using these addresses, however, because containers are usually treated in an ephemeral manner, it's recommended to use an [Internal Gateway](https://docs.hop.io/ignite/gateways#creating-a-gateway) to route between services instead of using the container IPs directly. Internal gateways give you an "internal domain" which you can use to dynamically resolve the IP addresses of containers under a specific deployment.
 
 For example, if you had an internal **redis** deployment which you wanted to connect to from an **api** deployment, you could create an internal gateway with the internal domain `redis.hop` and then use the `redis://redis.hop` hostname to connect to the redis deployment.

--- a/other-products/pipe/client-implementation.mdx
+++ b/other-products/pipe/client-implementation.mdx
@@ -57,7 +57,7 @@ in this section.
 
 `usePipeRoom` takes in an object as it's first and only argument, consisting of
 `joinToken` and `ref`, where `ref` is a
-[React reference](https://reactjs.org/refs-and-the-dom.html) to a video element.
+[React reference](https://react.dev/learn/manipulating-the-dom-with-refs) to a video element.
 
 Let's jump into an example bare-minimum component:
 

--- a/sdks/client/js.mdx
+++ b/sdks/client/js.mdx
@@ -24,7 +24,7 @@ yarn add @onehop/client
 
 ## Initializing the SDK
 
-Find your project ID on [this page](https://console.hop.io/auth).
+Find your project ID on [this page](https://console.hop.io/project/settings).
 
 ```jsx JSX
 import {hop} from '@onehop/client';

--- a/sdks/client/js.mdx
+++ b/sdks/client/js.mdx
@@ -35,3 +35,17 @@ hop.init({
 	projectId: 'project_xxx', // replace with your project ID
 });
 ```
+
+## Subscribe to a channel
+
+```jsx JSX
+import { hop } from '@onehop/client';
+
+const instance = await hop.init({ projectId: '' })
+const initialChannelState = instance.subscribeToChannel('HopIsReallyCool')
+
+// https://github.com/hopinc/client-js/blob/master/packages/client/src/leap/client.ts#L271
+instance.on('STATE_UPDATE', (data) => {
+  console.log(`Look at all those chickens: ${data}`)
+})
+```

--- a/sdks/client/js.mdx
+++ b/sdks/client/js.mdx
@@ -40,24 +40,24 @@ hop.init({
 
 Unprotected channels allow anyone to connect as long as they know the channel id. You can learn more about types of channels on [this page](https://react.dev/learn/manipulating-the-dom-with-refs).
 
-```jsx JSX
+```jsx
 import { hop } from '@onehop/client';
 
-const instance = await hop.init({ projectId: '' })
-const initialChannelState = instance.subscribeToChannel('HopIsReallyCool')
+const instance = await hop.init({ projectId: '' });
+const initialChannelState = instance.subscribeToChannel('HopIsReallyCool');
 
 instance.on('STATE_UPDATE', (data) => {
-  console.log(`Look at all those chickens: ${data}`)
-})
+  console.log(`Look at all those chickens: ${data}`);
+});
 ```
 
 ## Send a message to a channel
 
-```jsx JSX
+```jsx
 import { hop } from '@onehop/client';
 
-const instance = await hop.init({ projectId: '', token: '' })
-// instance.sendMessage(channel, event, payload)
-instance.sendMessage('votes', 'add', 1)
-instance.sendMessage('public-chat', 'kashcafe', { user: 'Kashall', message: 'This is a message!' })
+const instance = await hop.init({ projectId: '', token: '' });
+
+instance.sendMessage('votes', 'add', 1);
+instance.sendMessage('public-chat', 'kashcafe', { user: 'Kashall', message: 'This is a message!' });
 ```

--- a/sdks/client/js.mdx
+++ b/sdks/client/js.mdx
@@ -50,3 +50,14 @@ instance.on('STATE_UPDATE', (data) => {
   console.log(`Look at all those chickens: ${data}`)
 })
 ```
+
+## Send a message to a channel
+
+```jsx JSX
+import { hop } from '@onehop/client';
+
+const instance = await hop.init({ projectId: '', token: '' })
+// instance.sendMessage(channel, event, payload)
+instance.sendMessage('votes', 'add', 1)
+instance.sendMessage('public-chat', 'kashcafe', { user: 'Kashall', message: 'This is a message!' })
+```

--- a/sdks/client/js.mdx
+++ b/sdks/client/js.mdx
@@ -36,7 +36,9 @@ hop.init({
 });
 ```
 
-## Subscribe to a channel
+## Subscribing to a unprotected channel
+
+Unprotected channels allow anyone to connect as long as they know the channel id. You can learn more about types of channels on [this page](https://react.dev/learn/manipulating-the-dom-with-refs).
 
 ```jsx JSX
 import { hop } from '@onehop/client';
@@ -44,7 +46,6 @@ import { hop } from '@onehop/client';
 const instance = await hop.init({ projectId: '' })
 const initialChannelState = instance.subscribeToChannel('HopIsReallyCool')
 
-// https://github.com/hopinc/client-js/blob/master/packages/client/src/leap/client.ts#L271
 instance.on('STATE_UPDATE', (data) => {
   console.log(`Look at all those chickens: ${data}`)
 })


### PR DESCRIPTION
- Fixes broken link for finding your project id on Channel docs.
- Fixes broken link for Internal Gateways.
- Fixes broken link for obtaining a Hop PAT.
- Fixes broken link for react.dev
- Adds two examples on listening for channel state changes and sending a message to a channel.